### PR TITLE
SKYChatRecordChange init with event type

### DIFF
--- a/SKYKitChat/Classes/SKYChatExtension.m
+++ b/SKYKitChat/Classes/SKYChatExtension.m
@@ -801,7 +801,8 @@ NSString *const SKYChatRecordChangeUserInfoKey = @"recordChange";
                             }];
         }];
     } else if ([SKYChatRecordChange isRecordChangeEventType:dictionaryEventType]) {
-        SKYChatRecordChange *recordChange = [[SKYChatRecordChange alloc] initWithDictionary:data];
+        SKYChatRecordChange *recordChange = [[SKYChatRecordChange alloc] initWithDictionary:data
+                                                                                  eventType:dictionaryEventType];
         if (!recordChange) {
             return;
         }

--- a/SKYKitChat/Classes/SKYChatRecordChange.h
+++ b/SKYKitChat/Classes/SKYChatRecordChange.h
@@ -70,6 +70,6 @@ typedef NS_ENUM(NSInteger, SKYChatRecordChangeEvent) {
 /**
  Instantiates an instance of SKYChatRecordChange.
  */
-- (instancetype _Nullable)initWithDictionary:(NSDictionary<NSString *, id> *_Nonnull)dict;
+- (instancetype _Nullable)initWithDictionary:(NSDictionary<NSString *, id> *_Nonnull)dict eventType:(NSString * _Nullable)eventType;
 
 @end

--- a/SKYKitChat/Classes/SKYChatRecordChange.m
+++ b/SKYKitChat/Classes/SKYChatRecordChange.m
@@ -28,10 +28,9 @@
     return [@[ @"update", @"create", @"delete" ] containsObject:eventType];
 }
 
-- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict eventType:(NSString *)eventType
 {
     if ((self = [super init])) {
-        NSString *eventType = dict[@"event_type"];
         if ([eventType isEqualToString:@"create"]) {
             _event = SKYChatRecordChangeEventCreate;
         } else if ([eventType isEqualToString:@"update"]) {


### PR DESCRIPTION
data dictionary didn't contain event type information, passed as the second parameter.