### PR TITLE
Update SKYChatConversationViewController to use message cache

### DIFF
--- a/Example/Swift Example/ConversationDemoViewController.swift
+++ b/Example/Swift Example/ConversationDemoViewController.swift
@@ -42,7 +42,7 @@ extension ConversationDemoViewController: SKYChatConversationViewControllerDeleg
     func conversationViewController(
         _ controller: SKYChatConversationViewController,
         dateStringAt indexPath: IndexPath) -> NSAttributedString {
-        let msg = self.messages[indexPath.row]
+        let msg = self.messageAt(indexPath)
         let date = msg.creationDate()
 
         let dateFormatter: DateFormatter

--- a/Example/Swift Example/ConversationDemoViewController.swift
+++ b/Example/Swift Example/ConversationDemoViewController.swift
@@ -42,7 +42,7 @@ extension ConversationDemoViewController: SKYChatConversationViewControllerDeleg
     func conversationViewController(
         _ controller: SKYChatConversationViewController,
         dateStringAt indexPath: IndexPath) -> NSAttributedString {
-        let msg = self.messageAt(indexPath)
+        let msg = self.messageList.messageAt(indexPath.row)
         let date = msg.creationDate()
 
         let dateFormatter: DateFormatter

--- a/SKYKitChat/Classes/Core/Cache/SKYMessageCacheObject.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYMessageCacheObject.m
@@ -59,7 +59,7 @@
     }
 
     cacheObject.editionDate = [message.record objectForKey:@"edited_at"];
-    cacheObject.deleted = [message.record objectForKey:@"deleted"];
+    cacheObject.deleted = message.deleted;
     cacheObject.alreadySyncToServer = message.alreadySyncToServer;
     cacheObject.fail = message.fail;
     cacheObject.sendDate = message.sendDate;

--- a/SKYKitChat/Classes/Core/Records/SKYMessage.m
+++ b/SKYKitChat/Classes/Core/Records/SKYMessage.m
@@ -89,7 +89,7 @@ NSString *const SKYMessageDeletedKey = @"deleted";
 
 - (bool)deleted
 {
-    return self.record[SKYMessageDeletedKey];
+    return [self.record[SKYMessageDeletedKey] boolValue];
 }
 
 - (SKYMessageConversationStatus)conversationStatus

--- a/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
+++ b/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
@@ -25,6 +25,9 @@ import SKPhotoBrowser
 
 @objc public protocol SKYChatConversationViewControllerDelegate: class {
 
+    @objc optional func messagesFetchLimitInConversationViewController(
+        _ controller: SKYChatConversationViewController) -> UInt
+
     /**
      * For customizing message date display
      */
@@ -186,11 +189,21 @@ open class SKYChatConversationViewController: JSQMessagesViewController, AVAudio
     public var conversation: SKYConversation?
     public var participants: [String: SKYRecord] = [:]
     public var messageList: MessageList = MessageList()
-    public var messagesFetchLimit: UInt = 25
     public var typingIndicatorShowDuration: TimeInterval = TimeInterval(5)
     public var offsetYToLoadMore: CGFloat = CGFloat(400)
     fileprivate var hasMoreMessageToFetch: Bool = false
     fileprivate var isFetchingMessage: Bool = false
+
+    public var messagesFetchLimit: UInt {
+        get {
+            if let limit = self.delegate?.messagesFetchLimitInConversationViewController?(self) {
+                return limit
+            }
+
+            // default fetch limit
+            return 50
+        }
+    }
 
     public var messageChangeObserver: Any?
     public var typingIndicatorChangeObserver: Any?

--- a/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
+++ b/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
@@ -1355,6 +1355,8 @@ extension SKYChatConversationViewController {
         let chatExt = self.skygear.chatExtension
         self.isFetchingMessage = true
 
+        let cachedResult = NSMutableArray()
+
         self.delegate?.startFetchingMessages?(self)
         chatExt?.fetchMessages(
             conversation: self.conversation!,
@@ -1366,6 +1368,8 @@ extension SKYChatConversationViewController {
                     if (result?.count ?? 0) > 0 {
                         self.indicator?.stopAnimating()
                     }
+
+                    cachedResult.addObjects(from: result!)
                 } else {
                     self.isFetchingMessage = false
                     self.indicator?.stopAnimating()
@@ -1405,6 +1409,9 @@ extension SKYChatConversationViewController {
                     }
                 }
 
+                if !isCached {
+                    self.messageList.remove(cachedResult as! [SKYMessage])
+                }
                 self.messageList.merge(msgs)
 
                 if !isCached {


### PR DESCRIPTION
connect #115

Sorry, this PR is a bit messy, I try to summarise here.

- SKYChatConversationViewController will use cached result in fetchMessageAPI
- When server result received, cached result for the same fetch message api call will be discarded
    - This is like what is suggested in the guide of cached query
- deletedMessages are NOT included in fetchMessageAPI completion callback
    - Seems it is not needed, I don't want to make the API looks too complicated
- Maintain scroll position and scroll speed when load more

---

#129 would try to improve the performance by not sorting the whole list once when something is added to the message list