### PR TITLE
Introduce message operation cache objects

### DIFF
--- a/Example/Tests/SKYChatCacheControllerTests.m
+++ b/Example/Tests/SKYChatCacheControllerTests.m
@@ -274,33 +274,6 @@ SpecBegin(SKYChatCacheController)
                                                      [baseDate dateByAddingTimeInterval:i * 2000]);
                                          }
                                      }];
-
-            [cacheController
-                fetchUnsentMessagesWithConversationID:@"c0"
-                                           completion:^(NSArray<SKYMessage *> *_Nonnull messages) {
-                                               expect(messages.count).to.equal(1);
-                                               expect(messages[0].recordID.recordName)
-                                                   .to.equal(messageToSave.recordID.recordName);
-                                               expect(messages[0].sendDate)
-                                                   .to.equal(messageToSave.sendDate);
-                                           }];
-
-            [cacheController didSaveMessage:messageToSave error:nil];
-
-            [cacheController
-                fetchMessagesWithConversationID:@"c0"
-                                          limit:1
-                                     beforeTime:nil
-                                          order:nil
-                                     completion:^(NSArray<SKYMessage *> *messageList, BOOL isCached,
-                                                  NSError *error) {
-                                         SKYMessage *latestMessage = messageList.firstObject;
-                                         expect(latestMessage.recordID)
-                                             .to.equal(messageToSave.recordID);
-                                         expect(latestMessage.sendDate)
-                                             .to.equal(messageToSave.sendDate);
-                                         expect(latestMessage.alreadySyncToServer).to.beTruthy();
-                                     }];
         });
 
         it(@"didSave message, update the cache", ^{
@@ -313,7 +286,7 @@ SpecBegin(SKYChatCacheController)
             messageToSave.record[@"edited_at"] = [baseDate dateByAddingTimeInterval:50000];
             messageToSave.body = @"new message";
 
-            [cacheController didSaveMessage:messageToSave error:nil];
+            [cacheController saveMessage:messageToSave completion:nil];
 
             RLMRealm *realm = cacheController.store.realm;
             RLMResults<SKYMessageCacheObject *> *results =

--- a/Example/Tests/SKYChatCacheControllerTests.m
+++ b/Example/Tests/SKYChatCacheControllerTests.m
@@ -240,25 +240,20 @@ SpecBegin(SKYChatCacheController)
             messageToSave.body = @"new message";
             messageToSave.sendDate = [baseDate dateByAddingTimeInterval:50000];
 
-            [cacheController
-                saveMessage:messageToSave
-                 completion:^(SKYMessage *_Nullable message, NSError *_Nullable error) {
-                     expect(message.recordID).to.equal(messageToSave.recordID);
-                     expect(message.sendDate).to.equal(messageToSave.sendDate);
+            [cacheController didSaveMessage:messageToSave];
+            expect(message.recordID).to.equal(messageToSave.recordID);
+            expect(message.sendDate).to.equal(messageToSave.sendDate);
 
-                     RLMRealm *realm = cacheController.store.realm;
-                     RLMResults<SKYMessageCacheObject *> *results =
-                         [SKYMessageCacheObject objectsInRealm:realm
-                                                         where:@"recordID == %@", @"mm1"];
-                     expect(results.count).to.equal(1);
-                     expect(results[0].recordID).to.equal(messageToSave.recordID.recordName);
-                     expect(results[0].sendDate).to.equal(messageToSave.sendDate);
+            RLMRealm *realm = cacheController.store.realm;
+            RLMResults<SKYMessageCacheObject *> *results =
+                [SKYMessageCacheObject objectsInRealm:realm where:@"recordID == %@", @"mm1"];
+            expect(results.count).to.equal(1);
+            expect(results[0].recordID).to.equal(messageToSave.recordID.recordName);
+            expect(results[0].sendDate).to.equal(messageToSave.sendDate);
 
-                     results = [SKYMessageCacheObject allObjectsInRealm:realm];
-                     expect(results.count).to.equal(11);
-                 }];
+            results = [SKYMessageCacheObject allObjectsInRealm:realm];
+            expect(results.count).to.equal(11);
 
-            // assume that the save message to cache operation is sync
             [cacheController
                 fetchMessagesWithConversationID:@"c0"
                                           limit:100
@@ -286,7 +281,7 @@ SpecBegin(SKYChatCacheController)
             messageToSave.record[@"edited_at"] = [baseDate dateByAddingTimeInterval:50000];
             messageToSave.body = @"new message";
 
-            [cacheController saveMessage:messageToSave completion:nil];
+            [cacheController didSaveMessage:messageToSave];
 
             RLMRealm *realm = cacheController.store.realm;
             RLMResults<SKYMessageCacheObject *> *results =

--- a/Example/Tests/SKYChatCacheControllerTests.m
+++ b/Example/Tests/SKYChatCacheControllerTests.m
@@ -295,8 +295,6 @@ SpecBegin(SKYChatCacheController)
 
             SKYMessage *newMessage = [[results objectAtIndex:0] messageRecord];
             expect(newMessage.body).to.equal(messageToSave.body);
-            expect(newMessage.alreadySyncToServer).to.equal(YES);
-            expect(newMessage.fail).to.equal(NO);
         });
 
         it(@"delete message, update the cache", ^{

--- a/Example/Tests/SKYChatCacheControllerTests.m
+++ b/Example/Tests/SKYChatCacheControllerTests.m
@@ -443,6 +443,26 @@ describe(@"Cache Controller handle message operations", ^{
         }];
     });
 
+    it(@"mark pending messages as failed", ^{
+        RLMRealm *realm = cacheController.store.realm;
+
+        SKYMessage *message = [SKYMessage message];
+
+        SKYMessageOperation *operation =
+            [cacheController didStartMessage:message
+                              conversationID:@"c0"
+                               operationType:SKYMessageOperationTypeAdd];
+        expect(operation.status).to.equal(SKYMessageOperationStatusPending);
+
+        [cacheController markMessagesAsFailed];
+
+        SKYMessageOperationCacheObject *cacheObject =
+            [SKYMessageOperationCacheObject objectInRealm:realm
+                                            forPrimaryKey:operation.operationID];
+        SKYMessageOperation *operationInStore = [cacheObject messageOperation];
+        expect(operationInStore.status).to.equal(SKYMessageOperationStatusFailed);
+    });
+
     it(@"start message will create a pending message operation in store", ^{
         RLMRealm *realm = cacheController.store.realm;
 

--- a/Example/Tests/SKYChatExtensionTests.m
+++ b/Example/Tests/SKYChatExtensionTests.m
@@ -269,7 +269,6 @@ SpecBegin(SKYChatExtension)
                         completion:^(SKYMessage *_Nullable message, NSError *_Nullable error) {
                             expect(error).to.beNil();
                             expect(message.recordID.recordName).to.equal(@"mm1");
-                            expect(message.alreadySyncToServer).to.beTruthy();
                             expect(message.creationDate).toNot.beNil();
                             expect(message.sendDate).to.beNil();
                             checkRealm();
@@ -422,8 +421,6 @@ describe(@"Conversation messages, with error response", ^{
 
         waitUntil(^(DoneCallback done) {
             RLMRealm *realm = cacheController.store.realm;
-            expect(saved.alreadySyncToServer).to.beFalsy();
-            expect(saved.fail).to.beTruthy();
 
             [chatExtension addMessage:message
                        toConversation:conversation

--- a/Example/Tests/SKYChatExtensionTests.m
+++ b/Example/Tests/SKYChatExtensionTests.m
@@ -26,6 +26,7 @@
 #import "SKYConversation.h"
 #import "SKYMessageCacheObject.h"
 #import "SKYMessageOperationCacheObject.h"
+#import "SKYMessageOperation_Private.h"
 
 SpecBegin(SKYChatExtension)
 
@@ -191,6 +192,8 @@ SpecBegin(SKYChatExtension)
             [realm transactionWithBlock:^{
                 [realm deleteAllObjects];
             }];
+
+            [OHHTTPStubs removeAllStubs];
         });
 
         it(@"fetch messages", ^{
@@ -481,6 +484,210 @@ describe(@"Conversation messages, with error response", ^{
             expect(operation.message.recordID).to.equal(message.recordID);
             expect(operation.status).to.equal(SKYMessageOperationStatusPending);
             expect(operation.type).to.equal(SKYMessageOperationTypeDelete);
+        });
+    });
+});
+
+describe(@"Message Operations", ^{
+    __block SKYChatCacheController *cacheController = nil;
+    __block SKYChatExtension *chatExtension = nil;
+    __block NSDate *baseDate = nil;
+
+    beforeEach(^{
+        cacheController = [[SKYChatCacheController alloc]
+            initWithStore:[[SKYChatCacheRealmStore alloc] initInMemoryWithName:@"ChatTest"]];
+        baseDate = [NSDate dateWithTimeIntervalSince1970:0];
+        [SKYContainer defaultContainer].endPointAddress =
+            [NSURL URLWithString:@"https://test.skygeario.com/"];
+        chatExtension = [[SKYChatExtension alloc] initWithContainer:[SKYContainer defaultContainer]
+                                                    cacheController:cacheController];
+
+        // Setup cache
+        NSInteger messageCount = 10;
+        NSMutableArray<SKYMessageCacheObject *> *messages =
+            [NSMutableArray arrayWithCapacity:messageCount];
+
+        for (NSInteger i = 0; i < messageCount; i++) {
+            SKYMessage *message = [[SKYMessage alloc]
+                initWithRecordData:[SKYRecord
+                                       recordWithRecordType:@"message"
+                                                       name:[NSString
+                                                                stringWithFormat:@"m%ld", i]]];
+            message.conversationRef = [SKYReference
+                referenceWithRecordID:[SKYRecordID recordIDWithRecordType:@"conversation"
+                                                                     name:@"c0"]];
+            message.creationDate = [baseDate dateByAddingTimeInterval:i * 1000];
+            message.record[@"edited_at"] = [baseDate dateByAddingTimeInterval:i * 2000];
+            message.record[@"seq"] = @(i);
+
+            SKYMessageCacheObject *messageCacheObject =
+                [SKYMessageCacheObject cacheObjectFromMessage:message];
+            [messages addObject:messageCacheObject];
+        }
+
+        RLMRealm *realm = cacheController.store.realm;
+        [realm transactionWithBlock:^{
+            [realm addObjects:messages];
+        }];
+
+        // Setup network stub
+        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+            return YES;
+        }
+            withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+                return
+                    [OHHTTPStubsResponse responseWithError:[NSError errorWithDomain:NSURLErrorDomain
+                                                                               code:0
+                                                                           userInfo:nil]];
+            }];
+    });
+
+    afterEach(^{
+        RLMRealm *realm = cacheController.store.realm;
+        [realm transactionWithBlock:^{
+            [realm deleteAllObjects];
+        }];
+
+        [OHHTTPStubs removeAllStubs];
+    });
+
+    it(@"fetch message operations", ^{
+        SKYMessageOperation *operation =
+            [[SKYMessageOperation alloc] initWithMessage:[SKYMessage message]
+                                          conversationID:@"c0"
+                                                    type:SKYMessageOperationTypeAdd];
+        operation.status = SKYMessageOperationStatusFailed;
+        [cacheController.store setMessageOperations:@[ operation ]];
+
+        waitUntil(^(DoneCallback done) {
+            [chatExtension
+                fetchOutstandingMessageOperationsWithConverstionID:@"c0"
+                                                     operationType:SKYMessageOperationTypeAdd
+                                                        completion:^(NSArray<SKYMessageOperation *>
+                                                                         *messageOperations) {
+                                                            expect(messageOperations)
+                                                                .to.haveCount(1);
+                                                            expect(messageOperations[0].operationID)
+                                                                .to.equal(operation.operationID);
+                                                            done();
+                                                        }];
+        });
+    });
+
+    it(@"cancel message operations", ^{
+        SKYMessageOperation *operation =
+            [[SKYMessageOperation alloc] initWithMessage:[SKYMessage message]
+                                          conversationID:@"c0"
+                                                    type:SKYMessageOperationTypeAdd];
+        operation.status = SKYMessageOperationStatusFailed;
+        [cacheController.store setMessageOperations:@[ operation ]];
+
+        [chatExtension cancelMessageOperation:operation];
+        RLMRealm *realm = cacheController.store.realm;
+        expect([SKYMessageOperationCacheObject allObjectsInRealm:realm]).to.haveCount(0);
+    });
+
+    it(@"retry save message operations", ^{
+        SKYMessageOperation *operation =
+            [[SKYMessageOperation alloc] initWithMessage:[SKYMessage message]
+                                          conversationID:@"c0"
+                                                    type:SKYMessageOperationTypeAdd];
+        operation.status = SKYMessageOperationStatusFailed;
+        [cacheController.store setMessageOperations:@[ operation ]];
+
+        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+            NSArray<NSString *> *components = request.URL.pathComponents;
+            return [components[components.count - 2] isEqualToString:@"record"] &&
+                   [components.lastObject isEqualToString:@"save"];
+        }
+            withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+                NSDictionary *result = @{
+                    @"_type" : @"record",
+                    @"_access" : [NSNull null],
+                    @"_created_at" : @"2017-12-25T00:00:00.000000Z",
+                    @"_created_by" : @"u1",
+                    @"_id" : @"message/mm1",
+                    @"_ownerID" : @"u1",
+                    @"_updated_at" : @"2017-12-25T00:00:00.000000Z",
+                    @"_updated_by" : @"u1",
+                    @"body" : @"new message 1",
+                    @"conversation" : @{@"$id" : @"conversation/c0", @"$type" : @"ref"},
+                    @"deleted" : @NO,
+                    @"edited_at" : @{@"$date" : @"2017-12-25T00:00:00.000000Z", @"$type" : @"date"},
+                    @"edited_by" : @{@"$id" : @"user/u1", @"$type" : @"ref"},
+                    @"revision" : @1,
+                    @"seq" : @25,
+                };
+
+                NSDictionary *parameters =
+                    @{ @"database_id" : @"_public",
+                       @"result" : @[ result ] };
+                NSData *payload =
+                    [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
+
+                return [OHHTTPStubsResponse responseWithData:payload statusCode:200 headers:@{}];
+            }];
+
+        waitUntil(^(DoneCallback done) {
+            [chatExtension
+                retryMessageOperation:operation
+                           completion:^(SKYMessageOperation *messageOperation, SKYMessage *message,
+                                        NSError *error) {
+                               RLMRealm *realm = cacheController.store.realm;
+                               expect([SKYMessageOperationCacheObject allObjectsInRealm:realm])
+                                   .to.haveCount(0);
+                               done();
+                           }];
+        });
+    });
+
+    it(@"retry delete message operations", ^{
+        SKYMessageOperation *operation =
+            [[SKYMessageOperation alloc] initWithMessage:[SKYMessage message]
+                                          conversationID:@"c0"
+                                                    type:SKYMessageOperationTypeDelete];
+        operation.status = SKYMessageOperationStatusFailed;
+        [cacheController.store setMessageOperations:@[ operation ]];
+
+        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+            NSArray<NSString *> *components = request.URL.pathComponents;
+            return [components[components.count - 2] isEqualToString:@"chat"] &&
+                   [components.lastObject isEqualToString:@"delete_message"];
+        }
+            withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+                NSDictionary *result = @{
+                    @"_access" : [NSNull null],
+                    @"_created_at" : @"2017-12-01T00:00:00.000000Z",
+                    @"_created_by" : @"u1",
+                    @"_id" : @"message/m1",
+                    @"_ownerID" : @"u1",
+                    @"_updated_at" : @"2017-12-01T00:00:00.000000Z",
+                    @"_updated_by" : @"u1",
+                    @"conversation" : @{@"$id" : @"conversation/c0", @"$type" : @"ref"},
+                    @"deleted" : @YES,
+                    @"edited_at" : @{@"$date" : @"2017-12-01T00:00:00.000000Z", @"$type" : @"date"},
+                    @"edited_by" : @{@"$id" : @"user/u1", @"$type" : @"ref"},
+                    @"revision" : @1,
+                    @"seq" : @1,
+                };
+
+                NSDictionary *parameters = @{@"result" : result};
+                NSData *payload =
+                    [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
+
+                return [OHHTTPStubsResponse responseWithData:payload statusCode:200 headers:@{}];
+            }];
+
+        waitUntil(^(DoneCallback done) {
+            [chatExtension
+                retryMessageOperation:operation
+                           completion:^(SKYMessageOperation *messageOperation, SKYMessage *message,
+                                        NSError *error) {
+                               RLMRealm *realm = cacheController.store.realm;
+                               expect([SKYMessageOperationCacheObject allObjectsInRealm:realm])
+                                   .to.haveCount(0);
+                               done();
+                           }];
         });
     });
 });

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheController+Private.h
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheController+Private.h
@@ -28,6 +28,7 @@
 @property SKYChatCacheRealmStore *store;
 
 - (id)initWithStore:(SKYChatCacheRealmStore *)store;
+- (void)markMessagesAsFailed;
 
 @end
 

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.h
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.h
@@ -41,15 +41,9 @@
 
 - (void)saveMessage:(SKYMessage *)message completion:(SKYChatMessageCompletion)completion;
 
-- (void)didSaveMessage:(SKYMessage *)message error:(NSError *)error;
-
 - (void)didDeleteMessage:(SKYMessage *)message;
 
 - (void)handleRecordChange:(SKYChatRecordChange *)recordChange;
-
-- (void)fetchUnsentMessagesWithConversationID:(NSString *)conversationId
-                                   completion:(void (^_Nullable)(NSArray<SKYMessage *> *_Nonnull))
-                                                  completion;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.h
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.h
@@ -21,6 +21,7 @@
 
 #import "SKYChatExtension.h"
 #import "SKYMessage.h"
+#import "SKYMessageOperation.h"
 
 @interface SKYChatCacheController : NSObject
 
@@ -49,5 +50,24 @@
 - (void)fetchUnsentMessagesWithConversationID:(NSString *)conversationId
                                    completion:(void (^_Nullable)(NSArray<SKYMessage *> *_Nonnull))
                                                   completion;
+
+NS_ASSUME_NONNULL_BEGIN
+
+- (void)fetchMessageOperationsWithConversationID:(NSString *)conversationId
+                                   operationType:(SKYMessageOperationType)type
+                                      completion:
+                                          (SKYChatFetchMessageOperationsListCompletion)completion;
+
+- (SKYMessageOperation *)didStartMessage:(SKYMessage *)message
+                          conversationID:(NSString *)conversationID
+                           operationType:(SKYMessageOperationType)operationType;
+
+- (void)didCompleteMessageOperation:(SKYMessageOperation *)messageOperation;
+
+- (void)didFailMessageOperation:(SKYMessageOperation *)messageOperation error:(NSError *)error;
+
+- (void)didCancelMessageOperation:(SKYMessageOperation *)messageOperation;
+
+NS_ASSUME_NONNULL_END
 
 @end

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.h
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.h
@@ -39,7 +39,7 @@
 - (void)didFetchMessages:(NSArray<SKYMessage *> *)messages
          deletedMessages:(NSArray<SKYMessage *> *)deletedMessages;
 
-- (void)saveMessage:(SKYMessage *)message completion:(SKYChatMessageCompletion)completion;
+- (void)didSaveMessage:(SKYMessage *)message;
 
 - (void)didDeleteMessage:(SKYMessage *)message;
 

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.m
@@ -61,7 +61,6 @@ static NSString *SKYChatCacheStoreName = @"SKYChatCache";
         [NSPredicate predicateWithFormat:@"conversationID LIKE %@", conversationId],
         [NSPredicate predicateWithFormat:@"deleted == FALSE"],
         [NSCompoundPredicate orPredicateWithSubpredicates:@[
-            [NSPredicate predicateWithFormat:@"alreadySyncToServer != FALSE AND fail != TRUE"],
             [NSPredicate predicateWithFormat:@"sendDate == nil"],
         ]],
     ]];

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.m
@@ -124,14 +124,10 @@ static NSString *SKYChatCacheStoreName = @"SKYChatCache";
     [self.store setMessages:deletedMessages];
 }
 
-- (void)saveMessage:(SKYMessage *)message completion:(SKYChatMessageCompletion)completion
+- (void)didSaveMessage:(SKYMessage *)message
 {
     // cache unsaved message
     [self.store setMessages:@[ message ]];
-
-    if (completion) {
-        completion(message, nil);
-    }
 }
 
 - (void)didDeleteMessage:(SKYMessage *)message
@@ -154,7 +150,7 @@ static NSString *SKYChatCacheStoreName = @"SKYChatCache";
     switch (event) {
         case SKYChatRecordChangeEventCreate:
         case SKYChatRecordChangeEventUpdate:
-            [self saveMessage:message completion:nil];
+            [self didSaveMessage:message];
             break;
         case SKYChatRecordChangeEventDelete:
             [self didDeleteMessage:message];

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheController.m
@@ -35,6 +35,7 @@ static NSString *SKYChatCacheStoreName = @"SKYChatCache";
         SKYChatCacheRealmStore *store =
             [[SKYChatCacheRealmStore alloc] initWithName:SKYChatCacheStoreName];
         controller = [[SKYChatCacheController alloc] initWithStore:store];
+        [controller markMessagesAsFailed];
     });
 
     return controller;
@@ -199,6 +200,12 @@ static NSString *SKYChatCacheStoreName = @"SKYChatCache";
 - (void)didCancelMessageOperation:(SKYMessageOperation *)messageOperation
 {
     [self.store deleteMessageOperations:@[ messageOperation ]];
+}
+
+- (void)markMessagesAsFailed
+{
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"status == %@", @"pending"];
+    [self.store markMessagesAsFailedWithError:nil predicate:predicate];
 }
 
 @end

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.h
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.h
@@ -50,6 +50,6 @@
 
 - (void)deleteMessageOperations:(NSArray<SKYMessageOperation *> *)messageOperations;
 
-- (void)markMessagesAsFailedWithError:(NSError *)error predicate:(NSPredicate *)predicate;
+- (void)failMessageOperationsWithPredicate:(NSPredicate *)predicate error:(NSError *)error;
 
 @end

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.h
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.h
@@ -20,6 +20,7 @@
 #import <Realm/Realm.h>
 
 #import "SKYMessage.h"
+#import "SKYMessageOperation.h"
 
 @interface SKYChatCacheRealmStore : NSObject
 
@@ -38,5 +39,15 @@
 - (void)setMessages:(NSArray<SKYMessage *> *)messages;
 
 - (void)deleteMessages:(NSArray<SKYMessage *> *)messages;
+
+- (NSArray<SKYMessageOperation *> *)getMessageOperationsWithPredicate:(NSPredicate *)predicate
+                                                                limit:(NSInteger)limit
+                                                                order:(NSString *)order;
+
+- (SKYMessageOperation *)getMessageOperationWithID:(NSString *)operationID;
+
+- (void)setMessageOperations:(NSArray<SKYMessageOperation *> *)messageOperations;
+
+- (void)deleteMessageOperations:(NSArray<SKYMessageOperation *> *)messageOperations;
 
 @end

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.h
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.h
@@ -50,4 +50,6 @@
 
 - (void)deleteMessageOperations:(NSArray<SKYMessageOperation *> *)messageOperations;
 
+- (void)markMessagesAsFailedWithError:(NSError *)error predicate:(NSPredicate *)predicate;
+
 @end

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.m
@@ -187,4 +187,18 @@
     [self.realm commitWriteTransaction];
 }
 
+- (void)markMessagesAsFailedWithError:(NSError *)error predicate:(NSPredicate *)predicate;
+{
+    [self.realm beginWriteTransaction];
+
+    RLMResults<SKYMessageCacheObject *> *results =
+        [SKYMessageOperationCacheObject objectsInRealm:self.realm withPredicate:predicate];
+    [results setValuesForKeysWithDictionary:@{
+        @"status" : @"failed",
+        @"errorData" : [NSKeyedArchiver archivedDataWithRootObject:error],
+    }];
+
+    [self.realm commitWriteTransaction];
+}
+
 @end

--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.m
@@ -187,7 +187,7 @@
     [self.realm commitWriteTransaction];
 }
 
-- (void)markMessagesAsFailedWithError:(NSError *)error predicate:(NSPredicate *)predicate;
+- (void)failMessageOperationsWithPredicate:(NSPredicate *)predicate error:(NSError *)error
 {
     [self.realm beginWriteTransaction];
 

--- a/SKYKitChat/Classes/Core/Cache/SKYMessageCacheObject.h
+++ b/SKYKitChat/Classes/Core/Cache/SKYMessageCacheObject.h
@@ -31,9 +31,6 @@
 
 @property bool deleted;
 
-@property bool alreadySyncToServer;
-@property bool fail;
-
 @property NSData *recordData;
 
 @end

--- a/SKYKitChat/Classes/Core/Cache/SKYMessageCacheObject.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYMessageCacheObject.m
@@ -35,8 +35,6 @@
 {
     SKYRecord *record = [NSKeyedUnarchiver unarchiveObjectWithData:self.recordData];
     SKYMessage *message = [SKYMessage recordWithRecord:record];
-    message.alreadySyncToServer = self.alreadySyncToServer;
-    message.fail = self.fail;
     message.sendDate = self.sendDate;
     return message;
 }
@@ -61,8 +59,6 @@
 
     cacheObject.editionDate = [message.record objectForKey:@"edited_at"];
     cacheObject.deleted = message.deleted;
-    cacheObject.alreadySyncToServer = message.alreadySyncToServer;
-    cacheObject.fail = message.fail;
     cacheObject.sendDate = message.sendDate;
     cacheObject.recordData = [NSKeyedArchiver archivedDataWithRootObject:message.record];
 

--- a/SKYKitChat/Classes/Core/Cache/SKYMessageCacheObject.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYMessageCacheObject.m
@@ -18,6 +18,7 @@
 //
 
 #import "SKYMessageCacheObject.h"
+#import "SKYMessage.h"
 
 @implementation SKYMessageCacheObject
 

--- a/SKYKitChat/Classes/Core/Cache/SKYMessageOperationCacheObject.h
+++ b/SKYKitChat/Classes/Core/Cache/SKYMessageOperationCacheObject.h
@@ -1,0 +1,56 @@
+//
+//  SKYMessageOperationCacheObject.h
+//  SKYKitChat
+//
+//  Copyright 2016 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <Realm/Realm.h>
+#import <SKYKit/SKYKit.h>
+
+#import "SKYMessageOperation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SKYMessageOperationCacheObject : RLMObject
+
+@property NSString *operationID;
+@property NSString *recordID;
+@property NSString *conversationID;
+@property NSString *type;
+@property NSString *status;
+@property NSDate *sendDate;
+@property NSData *recordData;
+@property NSData *errorData;
+
+@end
+
+@interface SKYMessageOperationCacheObject (SKYMessageOperation)
+
++ (SKYMessageOperationStatus)messageOperationStatusWithKey:(NSString *)statusKey;
++ (NSString *)messageOperationStatusKeyWithStatus:(SKYMessageOperationStatus)status;
++ (SKYMessageOperationType)messageOperationTypeWithKey:(NSString *)typeKey;
++ (NSString *)messageOperationTypeKeyWithType:(SKYMessageOperationType)type;
+
+- (SKYMessageOperation *)messageOperation;
++ (SKYMessageOperationCacheObject *)cacheObjectFromMessageOperation:
+    (SKYMessageOperation *)messageOperation;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+RLM_ARRAY_TYPE(SKYMessageOperationCache)

--- a/SKYKitChat/Classes/Core/Cache/SKYMessageOperationCacheObject.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYMessageOperationCacheObject.m
@@ -1,0 +1,115 @@
+//
+//  SKYMessageOperationCacheObject.m
+//  SKYKitChat
+//
+//  Copyright 2016 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "SKYMessageOperationCacheObject.h"
+#import "SKYMessage.h"
+#import "SKYMessageOperation.h"
+
+NSString *const SKYMessageOperationStatusPendingKey = @"pending";
+NSString *const SKYMessageOperationStatusFailedKey = @"failed";
+NSString *const SKYMessageOperationTypeAddKey = @"add";
+NSString *const SKYMessageOperationTypeEditKey = @"edit";
+NSString *const SKYMessageOperationTypeDeleteKey = @"delete";
+
+@implementation SKYMessageOperationCacheObject
+
++ (NSString *)primaryKey
+{
+    return @"operationID";
+}
+
+@end
+
+@implementation SKYMessageOperationCacheObject (SKYMessageOperation)
+
++ (SKYMessageOperationStatus)messageOperationStatusWithKey:(NSString *)statusKey
+{
+    if ([statusKey isEqualToString:SKYMessageOperationStatusPendingKey]) {
+        return SKYMessageOperationStatusPending;
+    } else {
+        return SKYMessageOperationStatusFailed;
+    }
+}
+
++ (NSString *)messageOperationStatusKeyWithStatus:(SKYMessageOperationStatus)status
+{
+    switch (status) {
+        case SKYMessageOperationStatusPending:
+            return SKYMessageOperationStatusPendingKey;
+        default:
+            return SKYMessageOperationStatusFailedKey;
+    }
+}
+
++ (SKYMessageOperationType)messageOperationTypeWithKey:(NSString *)typeKey
+{
+    if ([typeKey isEqualToString:SKYMessageOperationTypeDeleteKey]) {
+        return SKYMessageOperationTypeDelete;
+    } else if ([typeKey isEqualToString:SKYMessageOperationTypeEditKey]) {
+        return SKYMessageOperationTypeEdit;
+    } else {
+        return SKYMessageOperationTypeAdd;
+    }
+}
+
++ (NSString *)messageOperationTypeKeyWithType:(SKYMessageOperationType)type
+{
+    switch (type) {
+        case SKYMessageOperationTypeEdit:
+            return SKYMessageOperationTypeEditKey;
+        case SKYMessageOperationTypeDelete:
+            return SKYMessageOperationTypeDeleteKey;
+        default:
+            return SKYMessageOperationTypeAddKey;
+    }
+}
+
+- (SKYMessageOperation *)messageOperation
+{
+    SKYRecord *record = [NSKeyedUnarchiver unarchiveObjectWithData:self.recordData];
+    SKYMessage *message = [SKYMessage recordWithRecord:record];
+    NSError *error = [NSKeyedUnarchiver unarchiveObjectWithData:self.errorData];
+    return [[SKYMessageOperation alloc]
+        initWithOperationID:self.operationID
+                    message:message
+             conversationID:self.conversationID
+                       type:[[self class] messageOperationTypeWithKey:self.type]
+                     status:[[self class] messageOperationStatusWithKey:self.status]
+                   sendDate:self.sendDate
+                      error:error];
+}
+
++ (SKYMessageOperationCacheObject *)cacheObjectFromMessageOperation:
+    (SKYMessageOperation *)messageOperation
+{
+    SKYMessageOperationCacheObject *cacheObject = [[SKYMessageOperationCacheObject alloc] init];
+
+    cacheObject.operationID = messageOperation.operationID;
+    cacheObject.recordID = messageOperation.message.recordID.recordName;
+    cacheObject.conversationID = messageOperation.conversationID;
+    cacheObject.type = [self messageOperationTypeKeyWithType:messageOperation.type];
+    cacheObject.status = [self messageOperationStatusKeyWithStatus:messageOperation.status];
+    cacheObject.recordData =
+        [NSKeyedArchiver archivedDataWithRootObject:messageOperation.message.record];
+    cacheObject.errorData = [NSKeyedArchiver archivedDataWithRootObject:messageOperation.error];
+    cacheObject.sendDate = messageOperation.sendDate;
+    return cacheObject;
+}
+
+@end

--- a/SKYKitChat/Classes/Core/Records/SKYMessage.h
+++ b/SKYKitChat/Classes/Core/Records/SKYMessage.h
@@ -41,9 +41,6 @@ typedef NS_ENUM(NSInteger, SKYMessageConversationStatus) {
 @property (assign, nonatomic, readonly) bool deleted;
 @property (strong, nonatomic, nullable) NSDate *sendDate;
 
-@property (assign, nonatomic) bool syncingToServer;
-@property (assign, nonatomic) bool alreadySyncToServer;
-@property (assign, nonatomic) bool fail;
 @property (assign, nonatomic, readonly) SKYMessageConversationStatus conversationStatus;
 
 + (instancetype _Nullable)message;

--- a/SKYKitChat/Classes/Core/Records/SKYMessage.m
+++ b/SKYKitChat/Classes/Core/Records/SKYMessage.m
@@ -37,7 +37,7 @@ NSString *const SKYMessageDeletedKey = @"deleted";
 
 + (instancetype)message
 {
-    return [[self alloc] initWithRecordType:@"message"];
+    return [[self alloc] init];
 }
 
 - (id)init

--- a/SKYKitChat/Classes/Core/SKYChatExtension.h
+++ b/SKYKitChat/Classes/Core/SKYChatExtension.h
@@ -57,7 +57,7 @@ extern NSString *_Nonnull const SKYChatTypingIndicatorUserInfoKey;
  */
 extern NSString *_Nonnull const SKYChatRecordChangeUserInfoKey;
 
-@class SKYConversation, SKYMessage, SKYUserChannel;
+@class SKYConversation, SKYMessage, SKYUserChannel, SKYMessageOperation;
 
 /**
  SKYChatExtension is a simple object that expose easy to use helper methods to develop a chat
@@ -82,6 +82,8 @@ typedef void (^SKYChatFetchConversationListCompletion)(
     NSArray<SKYConversation *> *_Nullable conversationList, NSError *_Nullable error);
 typedef void (^SKYChatFetchMessagesListCompletion)(NSArray<SKYMessage *> *_Nullable messageList,
                                                    BOOL isCached, NSError *_Nullable error);
+typedef void (^SKYChatFetchMessageOperationsListCompletion)(
+    NSArray<SKYMessageOperation *> *_Nullable messageOperationList);
 /**
  Gets or sets whether messages fetched from server are automatically marked as delivered.
 

--- a/SKYKitChat/Classes/Core/SKYChatExtension.h
+++ b/SKYKitChat/Classes/Core/SKYChatExtension.h
@@ -22,6 +22,7 @@
 #import "SKYChatReceipt.h"
 #import "SKYChatRecordChange.h"
 #import "SKYChatTypingIndicator.h"
+#import "SKYMessageOperation.h"
 
 /**
  When obtaining a dictionary containing unread count information, use this
@@ -84,6 +85,13 @@ typedef void (^SKYChatFetchMessagesListCompletion)(NSArray<SKYMessage *> *_Nulla
                                                    BOOL isCached, NSError *_Nullable error);
 typedef void (^SKYChatFetchMessageOperationsListCompletion)(
     NSArray<SKYMessageOperation *> *_Nullable messageOperationList);
+NS_ASSUME_NONNULL_BEGIN
+typedef void (^SKYMessageOperationCompletion)(SKYMessageOperation *messageOperation,
+                                              SKYMessage *_Nullable message,
+                                              NSError *_Nullable error);
+typedef void (^SKYMessageOperationListCompletion)(
+    NSArray<SKYMessageOperation *> *messageOperations);
+NS_ASSUME_NONNULL_END
 /**
  Gets or sets whether messages fetched from server are automatically marked as delivered.
 
@@ -725,4 +733,55 @@ subscribeToTypingIndicatorInConversation:(SKYConversation *_Nonnull)conversation
  @param NSNotification observer
  */
 - (void)unsubscribeToTypingIndicatorWithObserver:(id _Nonnull)observer;
+
+///-----------------------------------------
+/// @name Managing Failed Message Operations
+///-----------------------------------------
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Fetches outstanding message operations.
+
+ This method fetches outstanding message operations that is cached locally. Messages operations that
+ are pending or failed will be returned by this method. The application can display these
+ outstanding messages to the user and decide how to handle these outstanding operations.
+
+ @param conversationID The conversation ID of the message in a failed operation
+ @param operationType The type of the message operation
+ @param completion block to be called with an array of failed message operations
+ */
+- (void)fetchOutstandingMessageOperationsWithConverstionID:(NSString *)conversationID
+                                             operationType:(SKYMessageOperationType)operationType
+                                                completion:
+                                                    (SKYMessageOperationListCompletion)completion
+    /* clang-format off */ NS_SWIFT_NAME(fetchOutstandingMessageOperations(conversationID:operationType:completion:)); /* clang-format on */
+
+/**
+ Retry a failed message operation.
+
+ This method is called by the application when it decides to retry the message operation. The
+ operation will be removed and a new operation will be created. The message will be saved, edited,
+ or deleted according to the message operation type.
+
+ @param operation the message operation to retry
+ @param completion block to be called when the message operation completes
+ */
+- (void)retryMessageOperation:(SKYMessageOperation *)operation
+                   completion:(SKYMessageOperationCompletion)completion
+    /* clang-format off */ NS_SWIFT_NAME(retry(messageOperation:completion:)); /* clang-format on */
+
+/**
+ Cancel a failed message operation.
+
+ This method is called by the application when it decides the message operation will not be carried
+ out. The operation will be removed and no further actions will be performed.
+
+ @param operation the message operation to retry
+ */
+- (void)cancelMessageOperation:(SKYMessageOperation *)operation
+    /* clang-format off */ NS_SWIFT_NAME(cancel(messageOperation:)); /* clang-format on */
+
+NS_ASSUME_NONNULL_END
+
 @end

--- a/SKYKitChat/Classes/Core/SKYChatExtension.h
+++ b/SKYKitChat/Classes/Core/SKYChatExtension.h
@@ -368,20 +368,6 @@ typedef void (^SKYChatFetchMessageOperationsListCompletion)(
     /* clang-format off */ NS_SWIFT_NAME(addMessage(_:to:completion:)); /* clang-format on */
 
 /**
- Fetch unsent messages in a conversation.
-
- There are two types of unsent messages. First is pending messages that are added but no server
- response yet. Second is messages that are failed saved to server.
-
- @param conversationId ID of the conversation
- @param completion completion block
- */
-- (void)fetchUnsentMessagesWithConversationID:(NSString *_Nonnull)conversationId
-                                   completion:(void (^_Nullable)(NSArray<SKYMessage *> *_Nonnull))
-                                                  completion
-    /* clang-format off */ NS_SWIFT_NAME(fetchUnsentMessages(conversationID:completion:)); /* clang-format on */
-
-/**
  Fetch messages in a conversation.
 
  @param conversation conversation object

--- a/SKYKitChat/Classes/Core/SKYChatExtension.m
+++ b/SKYKitChat/Classes/Core/SKYChatExtension.m
@@ -309,8 +309,6 @@ NSString *const SKYChatRecordChangeUserInfoKey = @"recordChange";
                      SKYRecord *record = [deserializer recordWithDictionary:[obj copy]];
 
                      SKYMessage *msg = [[SKYMessage alloc] initWithRecordData:record];
-                     msg.alreadySyncToServer = true;
-                     msg.fail = false;
                      if (msg && msg.deleted) {
                          [deletedReturnArray addObject:msg];
                      } else if (msg && !msg.deleted) {
@@ -572,8 +570,6 @@ NSString *const SKYChatRecordChangeUserInfoKey = @"recordChange";
                 SKYRecord *record = [deserializer recordWithDictionary:[obj copy]];
 
                 SKYMessage *msg = [[SKYMessage alloc] initWithRecordData:record];
-                msg.alreadySyncToServer = true;
-                msg.fail = false;
                 if (msg) {
                     [returnArray addObject:msg];
                 }

--- a/SKYKitChat/Classes/Core/SKYChatExtension.m
+++ b/SKYKitChat/Classes/Core/SKYChatExtension.m
@@ -459,7 +459,7 @@ NSString *const SKYChatRecordChangeUserInfoKey = @"recordChange";
                       [self.cacheController didFailMessageOperation:operation error:error];
                   } else {
                       msg = [[SKYMessage alloc] initWithRecordData:record];
-                      [self.cacheController saveMessage:msg completion:nil];
+                      [self.cacheController didSaveMessage:msg];
                       [self.cacheController didCompleteMessageOperation:operation];
                   }
 

--- a/SKYKitChat/Classes/Core/SKYMessageOperation.h
+++ b/SKYKitChat/Classes/Core/SKYMessageOperation.h
@@ -1,0 +1,64 @@
+//
+//  SKYMessageOperation.h
+//  SKYKitChat
+//
+//  Copyright 2016 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <SKYKit/SKYKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SKYMessage;
+
+typedef NS_ENUM(NSInteger, SKYMessageOperationStatus) {
+    SKYMessageOperationStatusPending,
+    SKYMessageOperationStatusFailed,
+    SKYMessageOperationStatusSuccess
+};
+
+typedef NS_ENUM(NSInteger, SKYMessageOperationType) {
+    SKYMessageOperationTypeAdd,
+    SKYMessageOperationTypeEdit,
+    SKYMessageOperationTypeDelete
+};
+
+@interface SKYMessageOperation : NSObject
+
+@property (readonly, nonatomic) NSString *operationID;
+@property (readonly, nonatomic) SKYMessage *message;
+@property (readonly, nonatomic) NSString *conversationID;
+@property (readonly, nonatomic) SKYMessageOperationType type;
+@property (readonly, nonatomic) SKYMessageOperationStatus status;
+@property (readonly, copy, nonatomic, nullable) NSError *error;
+@property (readonly, nonatomic, nullable) NSDate *sendDate;
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithOperationID:(NSString *)operationID
+                            message:(SKYMessage *)message
+                     conversationID:(NSString *)conversationID
+                               type:(SKYMessageOperationType)type
+                             status:(SKYMessageOperationStatus)status
+                           sendDate:(NSDate *)sendDate
+                              error:(NSError *_Nullable)error NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithMessage:(SKYMessage *)message
+                 conversationID:(NSString *)conversationID
+                           type:(SKYMessageOperationType)type;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SKYKitChat/Classes/Core/SKYMessageOperation.m
+++ b/SKYKitChat/Classes/Core/SKYMessageOperation.m
@@ -1,0 +1,65 @@
+//
+//  SKYMessageOperation.m
+//  SKYKitChat
+//
+//  Copyright 2016 Oursky Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "SKYMessageOperation.h"
+#import "SKYMessageOperation_Private.h"
+
+@implementation SKYMessageOperation
+
+- (instancetype)initWithOperationID:(NSString *)operationID
+                            message:(SKYMessage *)message
+                     conversationID:(NSString *)conversationID
+                               type:(SKYMessageOperationType)type
+                             status:(SKYMessageOperationStatus)status
+                           sendDate:(NSDate *)sendDate
+                              error:(NSError *)error
+{
+    if ((self = [super init])) {
+        _operationID = [operationID copy];
+        _message = message;
+        _conversationID = [conversationID copy];
+        _type = type;
+        _status = status;
+        _sendDate = [sendDate copy];
+        _error = [error copy];
+    }
+    return self;
+}
+
+- (instancetype)initWithMessage:(SKYMessage *)message
+                 conversationID:(NSString *)conversationID
+                           type:(SKYMessageOperationType)type
+{
+    return [self initWithOperationID:[[NSUUID UUID] UUIDString]
+                             message:message
+                      conversationID:conversationID
+                                type:type
+                              status:SKYMessageOperationStatusPending
+                            sendDate:[NSDate date]
+                               error:nil];
+}
+
+- (id)init
+{
+    @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                   reason:@"message is required"
+                                 userInfo:nil];
+}
+
+@end

--- a/SKYKitChat/Classes/Core/SKYMessageOperation_Private.h
+++ b/SKYKitChat/Classes/Core/SKYMessageOperation_Private.h
@@ -1,5 +1,5 @@
 //
-//  SKYKitChat.h
+//  SKYMessageOperation_Private.h
 //  SKYKitChat
 //
 //  Copyright 2016 Oursky Ltd.
@@ -17,14 +17,15 @@
 //  limitations under the License.
 //
 
-#import "SKYChatExtension.h"
-#import "SKYChatReceipt.h"
-#import "SKYChatRecord.h"
-#import "SKYChatRecordChange.h"
-#import "SKYChatTypingIndicator.h"
-#import "SKYContainer+Chat.h"
-#import "SKYConversation.h"
-#import "SKYKitChat.h"
-#import "SKYMessage.h"
 #import "SKYMessageOperation.h"
-#import "SKYUserChannel.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SKYMessageOperation ()
+
+@property (readwrite, nonatomic) SKYMessageOperationStatus status;
+@property (readwrite, copy, nonatomic, nullable) NSError *error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
+++ b/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
@@ -201,13 +201,12 @@ open class MessageList {
         fatalError("messageIDs contains non String object")
     }
 
-    public func firstSuccessMessage() -> SKYMessage? {
+    public func first(where predicate: (_ message: SKYMessage) throws -> Bool) rethrows -> SKYMessage? {
         for messageID in self.messageIDs {
             if let id = messageID as? String {
-                let message = self.messages[id]
-                if let msg = message {
-                    if !msg.fail {
-                        return msg
+                if let message = self.messages[id] {
+                    if try predicate(message) {
+                        return message
                     }
                 }
             }
@@ -233,6 +232,7 @@ open class SKYChatConversationViewController: JSQMessagesViewController, AVAudio
     public var conversation: SKYConversation?
     public var participants: [String: SKYRecord] = [:]
     public var messageList: MessageList = MessageList()
+    public var messageOperationByIDs: [String: SKYMessageOperation] = [:]
     public var typingIndicatorShowDuration: TimeInterval = TimeInterval(5)
     public var offsetYToLoadMore: CGFloat = CGFloat(400)
     fileprivate var hasMoreMessageToFetch: Bool = false
@@ -836,7 +836,7 @@ extension SKYChatConversationViewController {
         }
 
         let textCustomization = SKYChatConversationView.UICustomization().textCustomization
-        if msg.fail {
+        if self.failedMessageOperation(message: msg) != nil {
             return NSAttributedString(string: textCustomization.messageSentFailed,
                                       attributes: [NSForegroundColorAttributeName: UIColor.red])
         }
@@ -1298,7 +1298,7 @@ extension SKYChatConversationViewController {
     }
 
     open func loadMoreMessage() {
-        if let firstMessage = self.messageList.firstSuccessMessage() {
+        if let firstMessage = self.firstSuccessMessage() {
             self.fetchMessages(before: firstMessage.creationDate())
         } else {
             self.fetchMessages(before: nil)
@@ -1307,7 +1307,7 @@ extension SKYChatConversationViewController {
 
     open override func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
         let message = self.messageList.messageAt(indexPath.row)
-        if !message.fail {
+        if self.failedMessageOperation(message: message) == nil {
             return super.collectionView(collectionView, canPerformAction: action, forItemAt: indexPath, withSender: sender)
         }
 
@@ -1332,13 +1332,24 @@ extension SKYChatConversationViewController {
     @objc func resendFailedMessage(_ message: SKYMessage) {
         self.messageList.remove([message])
         self.beforeSending(message: message)
-        self.send(message: message)
         self.collectionView.reloadData()
+        
+        if let operation = self.failedMessageOperation(message: message) {
+            self.removeMessageOperation(message: message)
+            self.skygear.chatExtension?.retry(messageOperation: operation, completion: { (messageOperation, message, error) in
+                
+            })
+        }
     }
 
     @objc func deleteFailedMessage(_ message: SKYMessage) {
         self.messageList.remove([message])
         self.collectionView.reloadData()
+        
+        if let operation = self.failedMessageOperation(message: message) {
+            self.removeMessageOperation(message: message)
+            self.skygear.chatExtension?.cancel(messageOperation: operation)
+        }
     }
 }
 
@@ -1684,14 +1695,52 @@ extension SKYChatConversationViewController {
 
             }, perRecordErrorHandler: nil)
     }
-
+    
+    func appendFailedMessageOperation(operation: SKYMessageOperation) {
+        let message = operation.message
+        let messageID = message.recordID().recordName
+        guard !self.messageList.contains(messageID) else {
+            return
+        }
+        
+        guard self.messageOperationByIDs[messageID] == nil else {
+            return
+        }
+        
+        self.messageList.append([message])
+        self.messageOperationByIDs[messageID] = operation
+    }
+    
+    func failedMessageOperation(message: SKYMessage) -> SKYMessageOperation? {
+        return self.messageOperationByIDs[message.recordID().recordName]
+    }
+    
+    func removeMessageOperation(message: SKYMessage) {
+        self.messageOperationByIDs.removeValue(forKey: message.recordID().recordName)
+    }
+    
+    func firstSuccessMessage() -> SKYMessage? {
+        return self.messageList.first { (message) -> Bool in
+            return self.messageOperationByIDs[message.recordID().recordName] == nil
+        }
+    }
+    
     open func fetchUnsentMessages() {
         let chatExt = self.skygear.chatExtension
-        chatExt?.fetchUnsentMessages(conversationID: self.conversation!.recordID().recordName,
-                                     completion: { (unsentMessages) in
-                                        self.delegate?.conversationViewController?(self, didFetchedMessages: unsentMessages, isCached: true)
-                                        self.messageList.merge(unsentMessages)
-                                        self.finishReceivingMessage()
+        chatExt?.fetchOutstandingMessageOperations(conversationID: self.conversation!.recordID().recordName,
+                                                   operationType: SKYMessageOperationType.add,
+                                                   completion: { (operations) in
+                                                    var unsentMessages = [SKYMessage]()
+                                                    for operation in operations {
+                                                        guard operation.status == SKYMessageOperationStatus.failed else {
+                                                            continue
+                                                        }
+                                                        
+                                                        self.appendFailedMessageOperation(operation: operation)
+                                                        unsentMessages.append(operation.message);
+                                                    }
+                                                    self.delegate?.conversationViewController?(self, didFetchedMessages: unsentMessages, isCached: true)
+                                                    self.finishReceivingMessage()
         })
     }
 
@@ -1753,6 +1802,10 @@ extension SKYChatConversationViewController {
                     }
                 }
                 self.messageList.merge(msgs)
+                for msg in msgs {
+                    self.removeMessageOperation(message: msg)
+                }
+
 
                 if !isCached {
                     if msgs.count > 0, let first = msgs.first {

--- a/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
+++ b/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
@@ -1802,6 +1802,11 @@ extension SKYChatConversationViewController {
                     }
                 }
                 self.messageList.merge(msgs)
+                // NOTE(cheungpat): Since we are fetching messages from
+                // the servers, these messages are assumed to be successful.
+                // Removing the failed operations because existence of
+                // a message operation is considered to be the message being
+                // failing.
                 for msg in msgs {
                     self.removeMessageOperation(message: msg)
                 }


### PR DESCRIPTION
The message operation cache objects is used by chat extension to persist
pending or failed operations. Successful message operations are automatically
removed from persistence store. It is possible for the user of the API
to retry failed message operations or cancel them.

The previous design had a problem that causes failed messages to appear
in the message cache. This implementation only changes the message cache
when the message operations are completed successfully.

**Note:** It is recommended to review this pull request by looking
at the commits (and messages) sequentially.

connects #155
connects #156
connects #157
connects #158