### PR TITLE
Check if realm is initialized in main thread

### DIFF
--- a/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.m
+++ b/SKYKitChat/Classes/Core/Cache/SKYChatCacheRealmStore.m
@@ -57,9 +57,15 @@
 
 - (void)createRealmWithConfiguration:(RLMRealmConfiguration *)config
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    void (^initializeRealm)() = ^() {
         self.realm = [RLMRealm realmWithConfiguration:config error:nil];
-    });
+    };
+
+    if ([NSThread isMainThread]) {
+        initializeRealm();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), initializeRealm);
+    }
 }
 
 - (NSArray<SKYMessage *> *)getMessagesWithPredicate:(NSPredicate *)predicate


### PR DESCRIPTION
The previous implementation always dispatch realm initialization to
main thread asynchronously. When the thread is already the main thread
the initialize will defer until the main thread is free again.