### PR TITLE
Add back `@objc` decorator to all public classes in Swift

### DIFF
--- a/SKYKitChat/Classes/UI/ConversationList/SKYChatConversationListViewController.swift
+++ b/SKYKitChat/Classes/UI/ConversationList/SKYChatConversationListViewController.swift
@@ -37,6 +37,7 @@ import SVProgressHUD
                                            didSelectConversation conversation: SKYConversation)
 }
 
+@objcMembers
 open class SKYChatConversationListViewController: UIViewController {
 
     public var skygear: SKYContainer = SKYContainer.default()

--- a/SKYKitChat/Classes/UI/ConversationList/SKYChatConversationTableViewCell.swift
+++ b/SKYKitChat/Classes/UI/ConversationList/SKYChatConversationTableViewCell.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+@objcMembers
 open class SKYChatConversationTableViewCell: UITableViewCell {
     let untitledConversation: String = "Untitled Conversation"
 

--- a/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationView.swift
+++ b/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationView.swift
@@ -36,7 +36,8 @@ import JSQMessagesViewController
     case otherParticipants
 }
 
-public class SKYChatConversationViewTextCustomization {
+@objcMembers
+public class SKYChatConversationViewTextCustomization: NSObject {
 
     public var sendButton = NSLocalizedString("Send", comment: "")
 
@@ -57,7 +58,8 @@ public class SKYChatConversationViewTextCustomization {
     }
 }
 
-public class SKYChatConversationViewCustomization {
+@objcMembers
+public class SKYChatConversationViewCustomization: NSObject {
     static var sharedInstance: SKYChatConversationViewCustomization?
 
     public var titleDisplayType: SKYChatConversationViewTitleOptions = .`default`
@@ -106,7 +108,7 @@ public class SKYChatConversationViewCustomization {
     public var incomingAudioMessageButtonColor: UIColor = UIColor.white
     public var outgoingAudioMessageButtonColor: UIColor = UIColor.jsq_messageBubbleBlue()
 
-    init() {
+    override init() {
         self.messageDateFormatter = {
             let df = DateFormatter()
             df.dateStyle = .medium
@@ -125,6 +127,7 @@ public class SKYChatConversationViewCustomization {
     }
 }
 
+@objcMembers
 open class SKYChatConversationView: JSQMessagesCollectionView {
     public static func UICustomization() -> SKYChatConversationViewCustomization {
          return SKYChatConversationViewCustomization.default()

--- a/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
+++ b/SKYKitChat/Classes/UI/ConversationView/SKYChatConversationViewController.swift
@@ -180,7 +180,8 @@ import JSQMessagesViewController
         failedFetchingMessagesWithError error: Error)
 }
 
-open class MessageList {
+@objcMembers
+open class MessageList: NSObject {
 
     public var messageIDs: NSMutableOrderedSet = NSMutableOrderedSet()
     public var messages: [String: SKYMessage] = [:]
@@ -275,6 +276,7 @@ open class MessageList {
     }
 }
 
+@objcMembers
 open class SKYChatConversationViewController: JSQMessagesViewController, AVAudioRecorderDelegate, SKYChatConversationImageItemDelegate {
 
     weak public var delegate: SKYChatConversationViewControllerDelegate?

--- a/SKYKitChat/Classes/UI/ConversationView/SKYMessage+JSQMessageMediaData.swift
+++ b/SKYKitChat/Classes/UI/ConversationView/SKYMessage+JSQMessageMediaData.swift
@@ -42,14 +42,15 @@ extension SKYMessage {
     }
 }
 
-public class JSQMessageMediaDataFactory {
+@objcMembers
+public class JSQMessageMediaDataFactory: NSObject {
     let assetCache: SKYAssetCache?
 
     public init(with assetCache: SKYAssetCache?) {
         self.assetCache = assetCache
     }
 
-    public convenience init() {
+    public convenience override init() {
         self.init(with: SKYAssetMemoryCache.shared())
     }
 

--- a/SKYKitChat/Classes/UI/DataCache.swift
+++ b/SKYKitChat/Classes/UI/DataCache.swift
@@ -19,13 +19,14 @@
 
 import LruCache
 
-public protocol DataCache {
+@objc public protocol DataCache {
     func getData(forKey key: String) -> Data?
     func set(data: Data, forKey key: String)
     func purgeData(forKey key: String)
     func purgeAll()
 }
 
+@objcMembers
 public class MemoryDataCache: DataCache {
     let store: LruCache
 

--- a/SKYKitChat/Classes/UI/ParticipantList/SKYChatParticipantListViewCell.swift
+++ b/SKYKitChat/Classes/UI/ParticipantList/SKYChatParticipantListViewCell.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+@objcMembers
 open class SKYChatParticipantListViewCell: UITableViewCell {
     let unnamedParticipant: String = "Unnamed Participant"
 

--- a/SKYKitChat/Classes/UI/ParticipantList/SKYChatParticipantListViewController.swift
+++ b/SKYKitChat/Classes/UI/ParticipantList/SKYChatParticipantListViewController.swift
@@ -49,6 +49,7 @@ public enum SKYChatParticipantQueryMethod: UInt {
                                            atIndexPath indexPath: IndexPath) -> UIImage?
 }
 
+@objcMembers
 open class SKYChatParticipantListViewController: UIViewController {
 
     static let queryMethodCoderKey = "QUERY_METHOD"

--- a/SKYKitChat/Classes/UI/SKYAssetCache.swift
+++ b/SKYKitChat/Classes/UI/SKYAssetCache.swift
@@ -17,13 +17,15 @@
 //  limitations under the License.
 //
 
-public protocol SKYAssetCache {
+
+@objc public protocol SKYAssetCache {
     func get(asset: SKYAsset) -> Data?
     func set(data: Data, for asset: SKYAsset)
     func purge(asset: SKYAsset)
     func purgeAll()
 }
 
+@objcMembers
 public class SKYAssetMemoryCache: SKYAssetCache {
     let store: MemoryDataCache
 

--- a/SKYKitChat/Classes/UI/SKYChatUIModelCustomization.swift
+++ b/SKYKitChat/Classes/UI/SKYChatUIModelCustomization.swift
@@ -19,7 +19,8 @@
 
 import UIKit
 
-public class SKYChatUIModelCustomization {
+@objcMembers
+public class SKYChatUIModelCustomization: NSObject {
     fileprivate static var sharedInstance: SKYChatUIModelCustomization?
 
     public fileprivate(set) var userNameField = "username"
@@ -29,7 +30,7 @@ public class SKYChatUIModelCustomization {
 // MARK: - Singleton
 public extension SKYChatUIModelCustomization {
 
-    static func `default`() -> SKYChatUIModelCustomization {
+    public static func `default`() -> SKYChatUIModelCustomization {
         if self.sharedInstance == nil {
             self.sharedInstance = SKYChatUIModelCustomization()
         }


### PR DESCRIPTION
connect #205

P.S. In Swift 3, XCode will do this for us by default while it turns off in Swift 4.

Ref. https://github.com/apple/swift-evolution/blob/master/proposals/0160-objc-inference.md
