### PR TITLE
Update podspec SKYKit/Core dependency to ~> 1.4

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -3,9 +3,6 @@ PODS:
   - CTAssetsPickerController (3.3.1):
     - PureLayout (~> 3.0.0)
   - Expecta (1.0.6)
-  - FMDB (2.6.2):
-    - FMDB/standard (= 2.6.2)
-  - FMDB/standard (2.6.2)
   - JSQMessagesViewController-Skygear (7.3.5.4):
     - JSQSystemSoundPlayer (~> 2.0.1)
   - JSQSystemSoundPlayer (2.0.1)
@@ -30,15 +27,14 @@ PODS:
     - Realm/Headers (= 3.0.2)
   - Realm/Headers (3.0.2)
   - SKPhotoBrowser (5.0.5)
-  - SKYKit/Core (1.3.2):
-    - FMDB (~> 2.6.0)
+  - SKYKit/Core (1.6.0):
     - MagicKit-Skygear (~> 0.0.6)
     - SocketRocket (~> 0.4)
   - SKYKitChat (1.5.0):
     - SKYKitChat/Core (= 1.5.0)
   - SKYKitChat/Core (1.5.0):
     - Realm (~> 3.0.1)
-    - SKYKit/Core (~> 1.3.1)
+    - SKYKit/Core (~> 1.4)
   - SKYKitChat/UI (1.5.0):
     - ALCameraViewController (~> 3.0)
     - CTAssetsPickerController (~> 3.3.1)
@@ -46,7 +42,7 @@ PODS:
     - JSQSystemSoundPlayer (~> 2.0.1)
     - LruCache (~> 0.1)
     - SKPhotoBrowser (~> 5.0.5)
-    - SKYKit/Core (~> 1.3.1)
+    - SKYKit/Core (~> 1.4)
     - SKYKitChat/Core
     - SVProgressHUD (~> 2.1.0)
   - SocketRocket (0.5.1)
@@ -69,7 +65,6 @@ SPEC CHECKSUMS:
   ALCameraViewController: 6398a9282057f709b87a1ecc52a83b48028ade64
   CTAssetsPickerController: b1d1d50ab87cf6b8b13531de5f4530482e7e53ed
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  FMDB: 854a0341b4726e53276f2a8996f06f1b80f9259a
   JSQMessagesViewController-Skygear: 363f8b91363e1c18039f2abdc53ca26050b57ca7
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
   Kingfisher: 1f9157d9c02b380cbd0b7cc890161195164eb634
@@ -79,8 +74,8 @@ SPEC CHECKSUMS:
   PureLayout: 4d550abe49a94f24c2808b9b95db9131685fe4cd
   Realm: 6f23fd1f178a09342eac21bfa7c2bf4312a7a180
   SKPhotoBrowser: 5969c3813727f11fe37bea74a40425cafcb32f61
-  SKYKit: 49a6bd447246b3a2d0a5f78127a1429476c48ccf
-  SKYKitChat: 63ec1f79421ca68bf7aadca0047121030d48af9b
+  SKYKit: b276cf12cbc79c47fd47ac83b5b836c46a5b25e9
+  SKYKitChat: 6689b452a9811ddf19a2c187be4185290cdd401e
   SocketRocket: d57c7159b83c3c6655745cd15302aa24b6bae531
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994

--- a/Example/SKYKitChat.xcodeproj/project.pbxproj
+++ b/Example/SKYKitChat.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 		A9C891E41FB404BF006B1112 /* SKYChatCacheControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SKYChatCacheControllerTests.m; sourceTree = "<group>"; };
 		ACF38D1BCF61531132635F9E /* Pods_Swift_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Swift_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C166D4E46298323DA868EE04 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		D848F7ED663C1EAF1A0DB616 /* SKYKitChat.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SKYKitChat.podspec; path = ../SKYKitChat.podspec; sourceTree = "<group>"; };
+		D848F7ED663C1EAF1A0DB616 /* SKYKitChat.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SKYKitChat.podspec; path = ../SKYKitChat.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		DF9DC27001F32EDA30C722A1 /* Pods-SKYKitChat_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SKYKitChat_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-SKYKitChat_Example/Pods-SKYKitChat_Example.release.xcconfig"; sourceTree = "<group>"; };
 		EEBC7866532676817C33E6D6 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */

--- a/SKYKitChat.podspec
+++ b/SKYKitChat.podspec
@@ -24,7 +24,7 @@ This is the client library for the Skygear Chat extension.
         ]
     }
 
-    sp.dependency 'SKYKit/Core', '~> 1.3.1'
+    sp.dependency 'SKYKit/Core', '~> 1.4'
     sp.dependency 'Realm', '~> 3.0.1'
   end
 
@@ -33,7 +33,7 @@ This is the client library for the Skygear Chat extension.
     sp.source_files = 'SKYKitChat/Classes/UI/**/*'
 
     sp.dependency 'SKYKitChat/Core'
-    sp.dependency 'SKYKit/Core',                       '~> 1.3.1'
+    sp.dependency 'SKYKit/Core',                       '~> 1.4'
     sp.dependency 'SVProgressHUD',                     '~> 2.1.0'
     sp.dependency 'ALCameraViewController',            '~> 3.0'
     sp.dependency 'LruCache',                          '~> 0.1'


### PR DESCRIPTION
Originally, chat SDK require `SKYKit/Core ~> 1.3.1` that user can only use core sdk version 1.3.x. 
Updated the podspec to `SKYKit/Core ~> 1.4`, so user can use newer core SDK with version 1.x where x >= 4